### PR TITLE
feat: user 프로필이미지 저장 및 삭제

### DIFF
--- a/trip-location/src/main/java/com/korea/triplocation/repository/UserRepository.java
+++ b/trip-location/src/main/java/com/korea/triplocation/repository/UserRepository.java
@@ -21,4 +21,6 @@ public interface UserRepository {
 
 
 	public PostsImg getPostsImgById(int postsImgId);
+
+    PostsImg getPostsImgByUserId(int userId);
 }

--- a/trip-location/src/main/java/com/korea/triplocation/service/UserService.java
+++ b/trip-location/src/main/java/com/korea/triplocation/service/UserService.java
@@ -109,6 +109,13 @@ public class UserService {
             user.setAddress(userModifyReqDto.getAddress());
         }
 		if (userModifyReqDto.getProfileImg() != null) {
+			PostsImg currentPostsImg = userRepository.getPostsImgByUserId(userId);
+			// If user has a profile image, delete it
+			if (currentPostsImg != null) {
+				deleteFile(currentPostsImg.getTempName());
+			}
+
+			// Upload new image
 			PostsImg postsImg = uploadFile(userId, userModifyReqDto.getProfileImg());
 			userRepository.postsImg(postsImg);
 			user.setPostsImgId(postsImg.getPostsImgId());
@@ -150,6 +157,16 @@ public class UserService {
 				.tempName(tempFileName)
 				.imgSize(Long.toString(file.getSize()))
 				.build();
+	}
+
+	private void deleteFile(String filename) {
+		Path uploadPath = Paths.get(filePath + "user/" + filename);
+
+		try {
+			Files.delete(uploadPath);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 	}
 	
 	public boolean resetPassword(ResetPasswordReqDto resetPasswordReqDto) {

--- a/trip-location/src/main/resources/mappers/UserMapper.xml
+++ b/trip-location/src/main/resources/mappers/UserMapper.xml
@@ -126,7 +126,20 @@
 		    posts_img_id = #{postsImgId}
 
 	</select>
-	
+	<select id="getPostsImgByUserId" resultType="com.korea.triplocation.domain.user.entity.PostsImg"
+			parameterType="int">
+		select
+		    posts_img_id,
+		    user_id,
+		    origin_name,
+		    temp_name,
+		    img_size
+		from
+		    posts_img_tb
+		where
+		    user_id = #{userId}
+	</select>
+
 	<update id="resetPassword">
 		
 		update


### PR DESCRIPTION
프로필이미지를 저장하고 나면 그대로 사진이 남아있다 이것을 업데이트된것만 남기고 이전 사진은 삭제